### PR TITLE
feat: surface migration failures

### DIFF
--- a/src/components/MigrationsProvider.tsx
+++ b/src/components/MigrationsProvider.tsx
@@ -75,7 +75,7 @@ export function Provider ({ children }: ProviderProps): ReactNode {
     if (runningMigrations[id]) return console.warn(`already started: ${id}`)
     if (!client) return console.warn('missing client')
 
-    log(id, 'starting migration...')
+    log(id, migration.progress?.pending ? 'resuming migration...' : 'starting migration...')
 
     const controller = new AbortController()
     runningMigrations[id] = controller


### PR DESCRIPTION
This PR surfaces details of uploads that failed to migrate, adding a list of root CIDs that need to be migrated manually, accompanied with a copy button allowing the user to copy the list of failures to the clipboard:

<img width="1582" alt="Screenshot 2024-07-03 at 10 37 05" src="https://github.com/storacha-network/console/assets/152863/4079f698-0ed5-4482-9b0c-fcb49696c240">

Amongst some other visual tweaks and fixes it also fixes the remove button to appear less friendly (and not popup a confirmation modal) when the migration has been completed:

<img width="213" alt="Screenshot 2024-07-03 at 10 35 23" src="https://github.com/storacha-network/console/assets/152863/ec6e94cb-97a8-413a-a686-4e01b897cd7c">

Hover state:

<img width="217" alt="Screenshot 2024-07-03 at 10 35 28" src="https://github.com/storacha-network/console/assets/152863/2cad5e2a-3bff-45e2-a315-8212ec7c3a02">
