### PR TITLE
chore: Update README with tweaks and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,27 +8,39 @@ Upload files & manage your spaces from your browser.
 
 To use the production site visit https://console.web3.storage
 
-To contribute and customize console, copy `.env.tpl` to `.env` and run the development server:
+To contribute and customize console:
 
 ```bash
+# First-time setup
+cp .env.tpl .env
+pnpm install
+
+# Run dev server
 pnpm dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+You can start editing the page by modifying [`src/app/page.tsx`](src/app/page.tsx). The page auto-updates as you edit the file.
+
+### Payment Info
+
+Normally, a new account must first add payment information through Stripe. You can skip this by setting in your `.env`:
+
+```ini
+NEXT_PUBLIC_DISABLE_PLAN_GATE=false
+```
+
+You can also go through the Stripe flow if you wish, [using a Stripe test card](https://docs.stripe.com/testing#use-test-cards).
 
 ### Using an alternate w3up service
 
-By default, this app connects to https://up.web3.storage. To use an alternate service, specify
-the service URL and DID in your environment variables, like:
+By default, this app connects to https://staging.up.web3.storage. To use an alternate service, specify the service URL and DID in your .env, like:
 
-```
+```ini
 NEXT_PUBLIC_W3UP_SERVICE_URL=https://your.w3up.service
 NEXT_PUBLIC_W3UP_SERVICE_DID=did:your-service-did
 ```
-
-An example `.env.local` file can be found in `.env.tpl`.
 
 If you are using `w3infra`, the service URL will be displayed as the `UploadApiStack`'s `ApiEndpoint` output once `npm start` has successfully set up your development environment.
 


### PR DESCRIPTION
A few things I hit while setting up the repo today:

* Move `.env` setup into code block, so it's easy to copy and paste.
* Add `pnpm install` step, too.
* Explain how to deal with Stripe in dev.
* Fix reference to top-level page file (looks like this wasn't updated with the upgrade to the App Router), and hyperlink it.
* Highlight .env file code blocks